### PR TITLE
Only load Steam API if Steam license type is set in loadConfig

### DIFF
--- a/src/XIVLauncher.NativeAOT/Program.cs
+++ b/src/XIVLauncher.NativeAOT/Program.cs
@@ -67,6 +67,35 @@ public class Program
         Log.Information("Starting a session({AppName})", AppName);
         Task.Run(Troubleshooting.LogTroubleshooting);
 
+
+        try
+        {
+            Steam = Environment.OSVersion.Platform switch
+            {
+                PlatformID.Win32NT => new WindowsSteam(),
+                PlatformID.Unix => new UnixSteam(),
+                _ => throw new PlatformNotSupportedException()
+            };
+
+            if (Config!.License! == License.Steam)
+            {
+                try
+                {
+                    var appId = Config!.IsFt == true ? STEAM_APP_ID_FT : STEAM_APP_ID;
+                    Steam.Initialize(appId);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Couldn't init Steam with game AppIds");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Steam couldn't load");
+            Troubleshooting.LogException(ex, "Steam couldn't load");
+        }
+
         var dalamudLoadInfo = new DalamudOverlayInfoProxy();
         DalamudUpdater = new DalamudUpdater(Storage.GetFolder("dalamud"), Storage.GetFolder("runtime"), Storage.GetFolder("dalamudAssets"), Storage.Root, null, "Control")
         {
@@ -142,35 +171,6 @@ public class Program
             DalamudLoadMethod = (DalamudLoadMethod)dalamudLoadMethod,
             DalamudLoadDelay = dalamudLoadDelay
         };
-
-        // only load Steam if we are using a Steam license
-        if (Config!.License! == License.Steam && Steam == null)
-        {
-            try
-            {
-                Steam = Environment.OSVersion.Platform switch
-                {
-                    PlatformID.Win32NT => new WindowsSteam(),
-                    PlatformID.Unix => new UnixSteam(),
-                    _ => throw new PlatformNotSupportedException()
-                };
-
-                try
-                {
-                    var appId = Config!.IsFt == true ? STEAM_APP_ID_FT : STEAM_APP_ID;
-                    Steam.Initialize(appId);
-                }
-                catch (Exception ex)
-                {
-                    Log.Error(ex, "Couldn't init Steam with game AppIds");
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Steam couldn't load");
-                Troubleshooting.LogException(ex, "Steam couldn't load");
-            }
-        }
     }
 
     [UnmanagedCallersOnly(EntryPoint = "fakeLogin")]


### PR DESCRIPTION
avoids having XIV on Mac open "holding up" the Steam account for players with Windows or Mac licenses, which prevents Steam from launching games on other computers. ideally, SteamAPI would only be initialised when launching the game so Steam license type users aren't affected either

i haven't been able to test if this commit breaks the launcher for Steam licenses but i assume it won't